### PR TITLE
exclude default features from actix-web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3.0"
+actix-web = { version = "3.0", default-features = false }
 actix-service = "1.0"
 futures = "0.3"
 governor = "0.3"


### PR DESCRIPTION
prevent unintended inclusion of default crates like brotli