### PR TITLE
Use EitherBody<B> to propagate responses in other middlewares.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ use governor::{
     Quota, RateLimiter,
 };
 
+use actix_http::body::EitherBody;
 use std::{cell::RefCell, marker::PhantomData, num::NonZeroU32, rc::Rc, sync::Arc, time::Duration};
 
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
@@ -469,7 +470,7 @@ where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     B: MessageBody,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type Transform = GovernorMiddleware<S, K, NoOpMiddleware>;
     type InitError = ();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,7 @@ where
     B: MessageBody,
     <S as Service<ServiceRequest>>::Future: Unpin,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type Transform = GovernorMiddleware<S, K, StateInformationMiddleware>;
     type InitError = ();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use actix_web::http::header::{HeaderName, HeaderValue};
-use actix_web::{body::MessageBody, error, Error};
+use actix_web::{body::MessageBody, Error};
 use futures::{future, TryFutureExt};
 use governor::clock::{Clock, DefaultClock};
 use governor::middleware::{NoOpMiddleware, StateInformationMiddleware};
@@ -93,7 +93,7 @@ where
 
 impl<F, B> Future for RateLimitHeaderFut<F>
 where
-    F: Future<Output = Result<ServiceResponse<B>, actix_web::Error>> + Unpin,
+    F: Future<Output = Result<ServiceResponse<EitherBody<B>>, Error>> + Unpin,
     B: MessageBody,
 {
     type Output = F::Output;
@@ -129,7 +129,7 @@ where
 
 impl<F, B> Future for WhitelistedHeaderFut<F>
 where
-    F: Future<Output = Result<ServiceResponse<B>, actix_web::Error>> + Unpin,
+    F: Future<Output = Result<ServiceResponse<EitherBody<B>>, Error>> + Unpin,
     B: MessageBody,
 {
     type Output = F::Output;
@@ -160,24 +160,29 @@ where
     B: MessageBody,
     S::Future: Unpin,
 {
-    type Response = S::Response;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = S::Error;
-    type Future = future::Either<
-        future::Ready<Result<ServiceResponse<B>, actix_web::Error>>,
-        future::Either<RateLimitHeaderFut<S::Future>, WhitelistedHeaderFut<S::Future>>,
+    type Future = Either<
+        Either<
+            RateLimitHeaderFut<
+                MapOk<S::Future, fn(ServiceResponse<B>) -> ServiceResponse<EitherBody<B>>>,
+            >,
+            WhitelistedHeaderFut<
+                MapOk<S::Future, fn(ServiceResponse<B>) -> ServiceResponse<EitherBody<B>>>,
+            >,
+        >,
+        Ready<Result<ServiceResponse<EitherBody<B>>, Error>>,
     >;
 
-    fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
-    }
+    forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         if let Some(configured_methods) = &self.methods {
             if !configured_methods.contains(req.method()) {
                 // The request method is not configured, we're ignoring this one.
                 let fut = self.service.call(req);
-                return future::Either::Right(future::Either::Right(WhitelistedHeaderFut {
-                    future: fut,
+                return Either::Left(Either::Right(WhitelistedHeaderFut {
+                    future: fut.map_ok(|resp| resp.map_into_left_body()),
                 }));
             }
         }
@@ -188,8 +193,8 @@ where
             Ok(key) => match self.limiter.check_key(&key) {
                 Ok(snapshot) => {
                     let fut = self.service.call(req);
-                    future::Either::Right(future::Either::Left(RateLimitHeaderFut {
-                        future: fut,
+                    Either::Left(Either::Left(RateLimitHeaderFut {
+                        future: fut.map_ok(|resp| resp.map_into_left_body()),
                         burst_size: snapshot.quota().burst_size().get(),
                         remaining_burst_capacity: snapshot.remaining_burst_capacity(),
                     }))
@@ -214,22 +219,22 @@ where
                         );
                     }
 
-                    let mut response_bulider = actix_web::HttpResponse::TooManyRequests();
-                    response_bulider
+                    let mut response_builder = actix_web::HttpResponse::TooManyRequests();
+                    response_builder
                         .insert_header(("x-ratelimit-after", wait_time))
                         .insert_header(("x-ratelimit-limit", negative.quota().burst_size().get()))
                         .insert_header(("x-ratelimit-remaining", 0));
                     let response = self
                         .key_extractor
-                        .exceed_rate_limit_response(&negative, response_bulider);
-                    future::Either::Left(future::err(
-                        error::InternalError::from_response("TooManyRequests", response).into(),
-                    ))
+                        .exceed_rate_limit_response(&negative, response_builder);
+
+                    let response = req.into_response(response);
+                    Either::Right(ok(response.map_into_right_body()))
                 }
             },
 
             // Extraction failed, stop right now.
-            Err(e) => future::Either::Left(future::err(e.into())),
+            Err(e) => Either::Right(future::err(e.into())),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -257,31 +257,27 @@ async fn test_server_use_headers() {
         .peer_addr(addr)
         .uri("/")
         .to_request();
-    let test = app.call(req).await.unwrap_err();
-    let err_response: HttpResponse = test.error_response();
-    assert_eq!(err_response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let test = app.call(req).await.unwrap();
+    assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
             .unwrap(),
         "0"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-limit"))
             .unwrap(),
         "2"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-remaining"))
             .unwrap(),
         "0"
     );
-    assert!(err_response
+    assert!(test
         .headers()
         .get(HeaderName::from_static("x-ratelimit-whitelisted"))
         .is_none());
@@ -323,38 +319,32 @@ async fn test_server_use_headers() {
         .peer_addr(addr)
         .uri("/")
         .to_request();
-    let test = app.call(req).await.unwrap_err();
-    let err_response: HttpResponse = test.error_response();
-    assert_eq!(err_response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let test = app.call(req).await.unwrap();
+    assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
             .unwrap(),
         "0"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-limit"))
             .unwrap(),
         "2"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-remaining"))
             .unwrap(),
         "0"
     );
-    assert!(err_response
+    assert!(test
         .headers()
         .get(HeaderName::from_static("x-ratelimit-whitelisted"))
         .is_none());
 
-    let body = actix_web::body::to_bytes(err_response.into_body())
-        .await
-        .unwrap();
+    let body = actix_web::body::to_bytes(test.into_body()).await.unwrap();
     assert_eq!(body, "Too many requests, retry in 0s");
 }
 
@@ -443,31 +433,27 @@ async fn test_method_filter_use_headers() {
         .peer_addr(addr)
         .uri("/")
         .to_request();
-    let test = app.call(req).await.unwrap_err();
-    let err_response: HttpResponse = test.error_response();
-    assert_eq!(err_response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let test = app.call(req).await.unwrap();
+    assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
             .unwrap(),
         "0"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-limit"))
             .unwrap(),
         "2"
     );
     assert_eq!(
-        err_response
-            .headers()
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-remaining"))
             .unwrap(),
         "0"
     );
-    assert!(err_response
+    assert!(test
         .headers()
         .get(HeaderName::from_static("x-ratelimit-whitelisted"))
         .is_none());


### PR DESCRIPTION
The current implementation does not work with other middlewares as it propagates using errors instead of EitherBody.
This means that it does not work correctly with logging, CORS, and other middlewares. Using EitherBody<B> should fix these issues.