### PR TITLE
Use `ok_or_esle` in function call (examples)

### DIFF
--- a/examples/custom_key_bearer.rs
+++ b/examples/custom_key_bearer.rs
@@ -22,14 +22,14 @@ impl KeyExtractor for UserToken {
             .get("Authorization")
             .and_then(|token| token.to_str().ok())
             .and_then(|token| token.strip_prefix("Bearer "))
-            .and_then(|token| Some(token.trim().to_owned()))
-            .ok_or(
+            .map(|token| token.trim().to_owned())
+            .ok_or_else(|| {
                 Self::KeyExtractionError::new(
                     r#"{ "code": 401, "msg": "You don't have permission to access"}"#,
                 )
                 .set_content_type(ContentType::json())
-                .set_status_code(StatusCode::UNAUTHORIZED),
-            )
+                .set_status_code(StatusCode::UNAUTHORIZED)
+            })
     }
 
     fn exceed_rate_limit_response(

--- a/examples/custom_key_ip.rs
+++ b/examples/custom_key_ip.rs
@@ -31,9 +31,9 @@ impl KeyExtractor for RealIpKeyExtractor {
             // The request is coming from the reverse proxy, we can trust the `Forwarded` or `X-Forwarded-For` headers
             Some(peer) if peer == reverse_proxy_ip => connection_info
                 .realip_remote_addr()
-                .ok_or(SimpleKeyExtractionError::new(
-                    "Could not extract real IP address from request",
-                ))
+                .ok_or_else(|| {
+                    SimpleKeyExtractionError::new("Could not extract real IP address from request")
+                })
                 .and_then(|str| {
                     SocketAddr::from_str(str)
                         .map(|socket| socket.ip())
@@ -47,9 +47,9 @@ impl KeyExtractor for RealIpKeyExtractor {
             // The request is not coming from the reverse proxy, we use peer IP
             _ => connection_info
                 .peer_addr()
-                .ok_or(SimpleKeyExtractionError::new(
-                    "Could not extract peer IP address from request",
-                ))
+                .ok_or_else(|| {
+                    SimpleKeyExtractionError::new("Could not extract peer IP address from request")
+                })
                 .and_then(|str| {
                     SocketAddr::from_str(str).map_err(|_| {
                         SimpleKeyExtractionError::new(


### PR DESCRIPTION
Improve examples﻿
