### PR TITLE
New requests_per_* API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-governor"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
 edition = "2021"
 description = "A rate-limiting middleware for actix-web backed by the governor crate"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ rate-limiting backed by [governor](https://github.com/antifuchs/governor).
 
 ## Features:
 
-- Simple to use
-- High customizability
-- High performance
-- Robust yet flexible API
++ Simple to use
++ High customizability
++ High performance
++ Robust yet flexible API
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ async fn index() -> impl Responder {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Allow bursts with up to five requests per IP address
-    // and replenishes one element every two seconds
+    // and replenishes two elements per second
     let governor_conf = GovernorConfigBuilder::default()
-        .seconds_per_request(2)
+        .requests_per_second(2)
         .burst_size(5)
         .finish()
         .unwrap();

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ rate-limiting backed by [governor](https://github.com/antifuchs/governor).
 
 ## Features:
 
-+ Simple to use
-+ High customizability
-+ High performance
-+ Robust yet flexible API
+- Simple to use
+- High customizability
+- High performance
+- Robust yet flexible API
 
 ## Example
 
@@ -29,7 +29,7 @@ async fn main() -> std::io::Result<()> {
     // Allow bursts with up to five requests per IP address
     // and replenishes one element every two seconds
     let governor_conf = GovernorConfigBuilder::default()
-        .per_second(2)
+        .seconds_per_request(2)
         .burst_size(5)
         .finish()
         .unwrap();
@@ -51,5 +51,5 @@ async fn main() -> std::io::Result<()> {
 
 ```toml
 [dependencies]
-actix-governor = "0.4"
+actix-governor = "0.6"
 ```

--- a/examples/custom_key_bearer.rs
+++ b/examples/custom_key_bearer.rs
@@ -65,7 +65,7 @@ async fn main() -> std::io::Result<()> {
     // Allow bursts with up to five requests per IP address
     // and replenishes one element every two seconds
     let governor_conf = GovernorConfigBuilder::default()
-        .per_second(20)
+        .seconds_per_request(2)
         .burst_size(5)
         .key_extractor(UserToken)
         .use_headers()

--- a/examples/custom_key_ip.rs
+++ b/examples/custom_key_ip.rs
@@ -78,7 +78,7 @@ async fn main() -> std::io::Result<()> {
     // Allow bursts with up to five requests per IP address
     // and replenishes one element every two seconds
     let governor_conf = GovernorConfigBuilder::default()
-        .per_second(20)
+        .seconds_per_request(2)
         .burst_size(5)
         .key_extractor(RealIpKeyExtractor)
         .finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
     /// **The interval must not be zero.**
     #[deprecated(
         since = "0.6.0",
-        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+        note = "Might be the inverse of what's expected. Use `const_seconds_per_request` as an exact replacement."
     )]
     pub const fn const_per_second(mut self, seconds: u64) -> Self {
         self.period = Duration::from_secs(seconds);
@@ -322,7 +322,7 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
     /// **The interval must not be zero.**
     #[deprecated(
         since = "0.6.0",
-        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+        note = "Might be the inverse of what's expected. Use `const_milliseconds_per_request` as an exact replacement."
     )]
     pub const fn const_per_millisecond(mut self, milliseconds: u64) -> Self {
         self.period = Duration::from_millis(milliseconds);
@@ -340,7 +340,7 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
     /// **The interval must not be zero.**
     #[deprecated(
         since = "0.6.0",
-        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+        note = "Might be the inverse of what's expected. Use `const_nanoseconds_per_request` as an exact replacement."
     )]
     pub const fn const_per_nanosecond(mut self, nanoseconds: u64) -> Self {
         self.period = Duration::from_nanos(nanoseconds);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!     // Allow bursts with up to five requests per IP address
 //!     // and replenishes one element every two seconds
 //!     let governor_conf = GovernorConfigBuilder::default()
-//!         .per_second(2)
+//!         .seconds_per_request(2)
 //!         .burst_size(5)
 //!         .finish()
 //!         .unwrap();
@@ -77,7 +77,7 @@
 //! use actix_governor::GovernorConfigBuilder;
 //!
 //! let config = GovernorConfigBuilder::default()
-//!     .per_second(4)
+//!     .seconds_per_request(4)
 //!     .burst_size(2)
 //!     .finish()
 //!     .unwrap();
@@ -200,7 +200,7 @@ const DEFAULT_BURST_SIZE: u32 = 8;
 /// use actix_governor::GovernorConfigBuilder;
 ///
 /// let config = GovernorConfigBuilder::default()
-///     .per_second(60)
+///     .seconds_per_request(60)
 ///     .burst_size(10)
 ///     .finish()
 ///     .unwrap();
@@ -212,7 +212,7 @@ const DEFAULT_BURST_SIZE: u32 = 8;
 /// use actix_governor::GovernorConfigBuilder;
 ///
 /// let config = GovernorConfigBuilder::default()
-///     .per_second(60)
+///     .seconds_per_request(60)
 ///     .burst_size(10)
 ///     .use_headers() // Add this
 ///     .finish()
@@ -284,24 +284,57 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
         self.period = duration;
         self
     }
+    /// Renamed to `const_seconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+    )]
+    pub const fn const_per_second(mut self, seconds: u64) -> Self {
+        self.period = Duration::from_secs(seconds);
+        self
+    }
     /// Set the interval after which one element of the quota is replenished in seconds.
     ///
     /// **The interval must not be zero.**
-    pub const fn const_per_second(mut self, seconds: u64) -> Self {
+    pub const fn const_second_per_request(mut self, seconds: u64) -> Self {
         self.period = Duration::from_secs(seconds);
+        self
+    }
+    /// Renamed to `const_milliseconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+    )]
+    pub const fn const_per_millisecond(mut self, milliseconds: u64) -> Self {
+        self.period = Duration::from_millis(milliseconds);
         self
     }
     /// Set the interval after which one element of the quota is replenished in milliseconds.
     ///
     /// **The interval must not be zero.**
-    pub const fn const_per_millisecond(mut self, milliseconds: u64) -> Self {
+    pub const fn const_milliseconds_per_request(mut self, milliseconds: u64) -> Self {
         self.period = Duration::from_millis(milliseconds);
+        self
+    }
+    /// Renamed to `const_nanoseconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+    )]
+    pub const fn const_per_nanosecond(mut self, nanoseconds: u64) -> Self {
+        self.period = Duration::from_nanos(nanoseconds);
         self
     }
     /// Set the interval after which one element of the quota is replenished in nanoseconds.
     ///
     /// **The interval must not be zero.**
-    pub const fn const_per_nanosecond(mut self, nanoseconds: u64) -> Self {
+    pub const fn const_nanoseconds_per_request(mut self, nanoseconds: u64) -> Self {
         self.period = Duration::from_nanos(nanoseconds);
         self
     }
@@ -332,24 +365,57 @@ impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBu
         self.period = duration;
         self
     }
+    /// Renamed to `seconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `seconds_per_request` as an exact replacement."
+    )]
+    pub fn per_second(&mut self, seconds: u64) -> &mut Self {
+        self.period = Duration::from_secs(seconds);
+        self
+    }
     /// Set the interval after which one element of the quota is replenished in seconds.
     ///
     /// **The interval must not be zero.**
-    pub fn per_second(&mut self, seconds: u64) -> &mut Self {
+    pub fn seconds_per_request(&mut self, seconds: u64) -> &mut Self {
         self.period = Duration::from_secs(seconds);
+        self
+    }
+    /// Renamed to `milliseconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `milliseconds_per_request` as an exact replacement."
+    )]
+    pub fn per_millisecond(&mut self, milliseconds: u64) -> &mut Self {
+        self.period = Duration::from_millis(milliseconds);
         self
     }
     /// Set the interval after which one element of the quota is replenished in milliseconds.
     ///
     /// **The interval must not be zero.**
-    pub fn per_millisecond(&mut self, milliseconds: u64) -> &mut Self {
+    pub fn milliseconds_per_request(&mut self, milliseconds: u64) -> &mut Self {
         self.period = Duration::from_millis(milliseconds);
+        self
+    }
+    /// Renamed to `nanoseconds_per_request`.
+    ///
+    /// **The interval must not be zero.**
+    #[deprecated(
+        since = "0.6.0",
+        note = "Might be the inverse of what's expected. Use `nanoseconds_per_request` as an exact replacement."
+    )]
+    pub fn per_nanosecond(&mut self, nanoseconds: u64) -> &mut Self {
+        self.period = Duration::from_nanos(nanoseconds);
         self
     }
     /// Set the interval after which one element of the quota is replenished in nanoseconds.
     ///
     /// **The interval must not be zero.**
-    pub fn per_nanosecond(&mut self, nanoseconds: u64) -> &mut Self {
+    pub fn nanoseconds_per_request(&mut self, nanoseconds: u64) -> &mut Self {
         self.period = Duration::from_nanos(nanoseconds);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,21 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
         self.period = duration;
         self
     }
+    /// Set the number of quota elements to replenish per second.
+    pub fn const_requests_per_second(self, count: u64) -> Self {
+        let replenish_interval_ns = Duration::from_secs(1).as_nanos() / count as u128;
+        self.const_nanoseconds_per_request(replenish_interval_ns as u64)
+    }
+    /// Set the number of quota elements to replenish per minute.
+    pub fn const_requests_per_minute(self, count: u64) -> Self {
+        let replenish_interval_ns = Duration::from_secs(60).as_nanos() / count as u128;
+        self.const_nanoseconds_per_request(replenish_interval_ns as u64)
+    }
+    /// Set the number of quota elements to replenish per hour.
+    pub fn const_requests_per_hour(self, count: u64) -> Self {
+        let replenish_interval_ns = Duration::from_secs(60 * 60).as_nanos() / count as u128;
+        self.const_nanoseconds_per_request(replenish_interval_ns as u64)
+    }
     /// Renamed to `const_seconds_per_request`.
     ///
     /// **The interval must not be zero.**
@@ -364,6 +379,21 @@ impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBu
     pub fn period(&mut self, duration: Duration) -> &mut Self {
         self.period = duration;
         self
+    }
+    /// Set the number of quota elements to replenish per second.
+    pub fn requests_per_second(&mut self, count: u64) -> &mut Self {
+        let replenish_interval_ns = Duration::from_secs(1).as_nanos() / count as u128;
+        self.nanoseconds_per_request(replenish_interval_ns as u64)
+    }
+    /// Set the number of quota elements to replenish per minute.
+    pub fn requests_per_minute(&mut self, count: u64) -> &mut Self {
+        let replenish_interval_ns = Duration::from_secs(60).as_nanos() / count as u128;
+        self.nanoseconds_per_request(replenish_interval_ns as u64)
+    }
+    /// Set the number of quota elements to replenish per hour.
+    pub fn requests_per_hour(&mut self, count: u64) -> &mut Self {
+        let replenish_interval_ns = Duration::from_secs(60 * 60).as_nanos() / count as u128;
+        self.nanoseconds_per_request(replenish_interval_ns as u64)
     }
     /// Renamed to `seconds_per_request`.
     ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,8 +47,8 @@ fn builder_test() {
     assert_eq!(GovernorConfigBuilder::default(), builder);
 
     let mut builder1 = builder.clone();
-    builder1.per_millisecond(5000);
-    let builder2 = builder.per_second(5);
+    builder1.milliseconds_per_request(5000);
+    let builder2 = builder.seconds_per_request(5);
 
     assert_eq!(&builder1, builder2);
 }
@@ -63,7 +63,7 @@ async fn test_server() {
     use actix_web::test;
 
     let config = GovernorConfigBuilder::default()
-        .per_millisecond(90)
+        .milliseconds_per_request(90)
         .burst_size(2)
         .finish()
         .unwrap();
@@ -143,7 +143,7 @@ async fn test_method_filter() {
     use actix_web::test;
 
     let config = GovernorConfigBuilder::default()
-        .per_millisecond(90)
+        .milliseconds_per_request(90)
         .burst_size(2)
         .methods(vec![Method::GET])
         .finish()
@@ -206,7 +206,7 @@ async fn test_server_use_headers() {
     use actix_web::test;
 
     let config = GovernorConfigBuilder::default()
-        .per_millisecond(90)
+        .milliseconds_per_request(90)
         .burst_size(2)
         .use_headers()
         .finish()
@@ -380,7 +380,7 @@ async fn test_method_filter_use_headers() {
     use actix_web::test;
 
     let config = GovernorConfigBuilder::default()
-        .per_millisecond(90)
+        .milliseconds_per_request(90)
         .burst_size(2)
         .methods(vec![Method::GET])
         .use_headers()
@@ -544,7 +544,7 @@ async fn test_json_error_response() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(FooKeyExtractor)
         .finish()
         .unwrap();
@@ -581,7 +581,7 @@ async fn test_key_extraction_whitelisted_key() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(WhitelistedKeyExtractor)
         .finish()
         .unwrap();
@@ -621,7 +621,7 @@ async fn test_key_extraction_whitelisted_key_with_header() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(WhitelistedKeyExtractor)
         .use_headers()
         .finish()
@@ -663,7 +663,7 @@ async fn test_key_extraction_unwhitelisted_key_with_header() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(WhitelistedKeyExtractor)
         .use_headers()
         .finish()
@@ -755,7 +755,7 @@ async fn test_forbidden_response_error() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(FooKeyExtractor)
         .finish()
         .unwrap();
@@ -807,7 +807,7 @@ async fn test_html_error_response() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(FooKeyExtractor)
         .finish()
         .unwrap();
@@ -860,7 +860,7 @@ async fn test_network_authentication_required_response_error() {
 
     let config = GovernorConfigBuilder::default()
         .burst_size(2)
-        .per_second(3)
+        .seconds_per_request(3)
         .key_extractor(FooKeyExtractor)
         .finish()
         .unwrap();
@@ -899,7 +899,7 @@ async fn test_server_permissive() {
     use actix_web::web::Bytes;
 
     let config = GovernorConfigBuilder::default()
-        .per_millisecond(90)
+        .milliseconds_per_request(90)
         .burst_size(2)
         .permissive(true)
         .finish()


### PR DESCRIPTION
This addresses #49. The current `.per_second` API is the inverse of governor's. There, it means "the number of requests to allow per second". Here, it means "the number of seconds between requests".

It would be bad to break the current API. Users who've written `.per_second(10)`, meaning "about 6 per minute", should not find their server suddenly honoring "about 600 per minute". That would be bad. Instead, this creates a new API by deprecating the old methods and renaming them:

- `.per_second` -> `.seconds_per_request`
- `.per_millisecond` -> `.milliseconds_per_request`
- `.per_nanosecond` -> `.nanoseconds_per_request`

That means current code will still work exactly as before, but devs will be nudged to rename their calls. It also adds new methods:

- `.requests_per_second` (corresponding to governor's `. per_second`)
- `.requests_per_minute` (governor's `.per_minute`)
- `.requests_per_hour` (governor's `.per_hour`)

There's no `.requests_per_{milli,nano}second` because at that point the rates aren't actually being limited on hardware that exists today.

I think that `.requests_per_second` will be the most frequently used. That's what motivated me to file the bug and write this patch: I wanted to limit an API to 2 calls per second. When I wrote `.per_second(2)`, I was surprised to find it meant 1 call every 2 seconds. I ended up with `.per_millisecond(500)`, which to me _sounded_ like "500 per millisecond". With the renamed API, that would be `.milliseconds_per_request(500)` which I find to be a lot clearer, or `.requests_per_second(2)` which is also clear to me.