### PR TITLE
Include standard retry-after header in addition to x-ratelimit-after

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 //!
 //! # Add x-ratelimit headers
 //!
-//! By default, `x-ratelimit-after` is enabled but if you want to enable `x-ratelimit-limit`, `x-ratelimit-whitelisted` and `x-ratelimit-remaining` use [`use_headers`] method
+//! By default, `retry-after` and `x-ratelimit-after` are enabled but if you want to enable `x-ratelimit-limit`, `x-ratelimit-whitelisted` and `x-ratelimit-remaining` use [`use_headers`] method
 //!
 //! [`use_headers`]: crate::GovernorConfigBuilder::use_headers()
 //!
@@ -491,12 +491,13 @@ impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBu
     }
 
     /// Set x-ratelimit headers to response, the headers is
+    /// - `retry-after`             - Number of seconds in which the API will become available after its rate limit has been exceeded
+    /// - `x-ratelimit-after`       - Number of seconds in which the API will become available after its rate limit has been exceeded
     /// - `x-ratelimit-limit`       - Request limit
     /// - `x-ratelimit-remaining`   - The number of requests left for the time window
-    /// - `x-ratelimit-after`       - Number of seconds in which the API will become available after its rate limit has been exceeded
     /// - `x-ratelimit-whitelisted` - If the request method not in methods, this header will be add it, use [`methods`] to add methods
     ///
-    /// By default `x-ratelimit-after` is enabled, with [`use_headers`] will enable `x-ratelimit-limit`, `x-ratelimit-whitelisted` and `x-ratelimit-remaining`
+    /// By default `retry-after` and `x-ratelimit-after` are enabled, with [`use_headers`] will enable `x-ratelimit-limit`, `x-ratelimit-whitelisted` and `x-ratelimit-remaining`
     ///
     /// [`methods`]: crate::GovernorConfigBuilder::methods()
     /// [`use_headers`]: Self::use_headers

--- a/src/service.rs
+++ b/src/service.rs
@@ -94,6 +94,7 @@ where
                             }
 
                             let mut response_builder = actix_web::HttpResponse::TooManyRequests();
+                            response_builder.insert_header(("retry-after", wait_time));
                             response_builder.insert_header(("x-ratelimit-after", wait_time));
                             let response = self
                                 .key_extractor
@@ -298,6 +299,7 @@ where
 
                             let mut response_builder = actix_web::HttpResponse::TooManyRequests();
                             response_builder
+                                .insert_header(("retry-after", wait_time))
                                 .insert_header(("x-ratelimit-after", wait_time))
                                 .insert_header(("x-ratelimit-limit", burst_size))
                                 .insert_header(("x-ratelimit-remaining", 0));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,6 +103,12 @@ async fn test_server() {
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(
         test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
+    assert_eq!(
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
             .unwrap(),
         "0"
@@ -127,6 +133,12 @@ async fn test_server() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -184,6 +196,12 @@ async fn test_server_per_second() {
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(
         test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
+    assert_eq!(
+        test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
             .unwrap(),
         "0"
@@ -208,6 +226,12 @@ async fn test_server_per_second() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -264,6 +288,12 @@ async fn test_method_filter() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -324,6 +354,10 @@ async fn test_server_use_headers() {
     );
     assert!(test
         .headers()
+        .get(HeaderName::from_static("retry-after"))
+        .is_none());
+    assert!(test
+        .headers()
         .get(HeaderName::from_static("x-ratelimit-after"))
         .is_none());
     assert!(test
@@ -352,6 +386,10 @@ async fn test_server_use_headers() {
     );
     assert!(test
         .headers()
+        .get(HeaderName::from_static("retry-after"))
+        .is_none());
+    assert!(test
+        .headers()
         .get(HeaderName::from_static("x-ratelimit-after"))
         .is_none());
     assert!(test
@@ -366,6 +404,12 @@ async fn test_server_use_headers() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -414,6 +458,10 @@ async fn test_server_use_headers() {
     );
     assert!(test
         .headers()
+        .get(HeaderName::from_static("retry-after"))
+        .is_none());
+    assert!(test
+        .headers()
         .get(HeaderName::from_static("x-ratelimit-after"))
         .is_none());
     assert!(test
@@ -428,6 +476,12 @@ async fn test_server_use_headers() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -500,6 +554,10 @@ async fn test_method_filter_use_headers() {
     );
     assert!(test
         .headers()
+        .get(HeaderName::from_static("retry-after"))
+        .is_none());
+    assert!(test
+        .headers()
         .get(HeaderName::from_static("x-ratelimit-after"))
         .is_none());
     assert!(test
@@ -528,6 +586,10 @@ async fn test_method_filter_use_headers() {
     );
     assert!(test
         .headers()
+        .get(HeaderName::from_static("retry-after"))
+        .is_none());
+    assert!(test
+        .headers()
         .get(HeaderName::from_static("x-ratelimit-after"))
         .is_none());
     assert!(test
@@ -542,6 +604,12 @@ async fn test_method_filter_use_headers() {
         .to_request();
     let test = app.call(req).await.unwrap();
     assert_eq!(test.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        test.headers()
+            .get(HeaderName::from_static("retry-after"))
+            .unwrap(),
+        "0"
+    );
     assert_eq!(
         test.headers()
             .get(HeaderName::from_static("x-ratelimit-after"))
@@ -586,6 +654,10 @@ async fn test_method_filter_use_headers() {
     assert!(test
         .headers()
         .get(HeaderName::from_static("x-ratelimit-remaining"))
+        .is_none());
+    assert!(test
+        .headers()
+        .get(HeaderName::from_static("retry-after"))
         .is_none());
     assert!(test
         .headers()
@@ -725,6 +797,7 @@ async fn test_key_extraction_whitelisted_key_with_header() {
         );
         assert_eq!(test.headers().get("x-ratelimit-limit"), None);
         assert_eq!(test.headers().get("x-ratelimit-remaining"), None);
+        assert_eq!(test.headers().get("retry-after"), None);
         assert_eq!(test.headers().get("x-ratelimit-after"), None);
     };
     // First request (whitelisted)
@@ -772,6 +845,7 @@ async fn test_key_extraction_unwhitelisted_key_with_header() {
         test.headers().get("x-ratelimit-remaining"),
         Some(&"1".parse().unwrap())
     );
+    assert_eq!(test.headers().get("retry-after"), None);
     assert_eq!(test.headers().get("x-ratelimit-after"), None);
     // Second request (not whitelisted)
     let mut req = test::TestRequest::get().uri("/").to_request();
@@ -790,6 +864,7 @@ async fn test_key_extraction_unwhitelisted_key_with_header() {
         test.headers().get("x-ratelimit-remaining"),
         Some(&"0".parse().unwrap())
     );
+    assert_eq!(test.headers().get("retry-after"), None);
     assert_eq!(test.headers().get("x-ratelimit-after"), None);
     // Third request (not whitelisted)
     let mut req = test::TestRequest::get().uri("/").to_request();
@@ -807,6 +882,10 @@ async fn test_key_extraction_unwhitelisted_key_with_header() {
     assert_eq!(
         test.headers().get("x-ratelimit-remaining"),
         Some(&"0".parse().unwrap())
+    );
+    assert_eq!(
+        test.headers().get("retry-after"),
+        Some(&"2".parse().unwrap())
     );
     assert_eq!(
         test.headers().get("x-ratelimit-after"),


### PR DESCRIPTION
The standard `retry-after` header can (also) be used with 429 Too Many Requests to indicate how long the client should wait before trying again.[1]

In fact, some tools apparently honor it but not the non-standard `x-ratelimit-after`.[2]

For completeness and best compatibility, include both in all responses.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
[2]: https://github.com/benwis/tower-governor/pull/40