### PR TITLE
[adhoc] Corrects inline comment on token example

### DIFF
--- a/examples/custom_key_bearer.rs
+++ b/examples/custom_key_bearer.rs
@@ -62,7 +62,7 @@ async fn index() -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Allow bursts with up to five requests per IP address
+    // Allow bursts with up to five requests per bearer token
     // and replenishes one element every two seconds
     let governor_conf = GovernorConfigBuilder::default()
         .seconds_per_request(2)


### PR DESCRIPTION
In the bearer token example, an inline comment referred to IP address, which I believe is incorrect in this specific example. This PR changes it to reflect the rate limits are keyed off the bearer token for clarity.