### PR TITLE
Don't return error from middleware

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,7 @@
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use actix_web::http::header::{HeaderName, HeaderValue};
 use actix_web::{body::MessageBody, Error};
+use actix_web::ResponseError;
 use futures::{future, TryFutureExt};
 use governor::clock::{Clock, DefaultClock};
 use governor::middleware::{NoOpMiddleware, StateInformationMiddleware};
@@ -115,7 +116,8 @@ where
                     let fut = self.service.call(req);
                     Either::Left(fut.map_ok(|resp| resp.map_into_left_body()))
                 } else {
-                    Either::Right(future::err(e.into()))
+                    let response = req.into_response(e.error_response());
+                    Either::Right(ok(response.map_into_right_body()))
                 }
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -849,9 +849,9 @@ async fn test_forbidden_response_error() {
 
     // First request
     let req = test::TestRequest::get().uri("/").to_request();
-    let err_res = app.call(req).await.unwrap_err();
+    let err_res = app.call(req).await.unwrap();
     assert_eq!(
-        err_res.as_response_error().status_code(),
+        err_res.response().status(),
         StatusCode::FORBIDDEN
     );
 }
@@ -954,9 +954,9 @@ async fn test_network_authentication_required_response_error() {
 
     // First request
     let req = test::TestRequest::get().uri("/").to_request();
-    let err_res = app.call(req).await.unwrap_err();
+    let err_res = app.call(req).await.unwrap();
     assert_eq!(
-        err_res.as_response_error().status_code(),
+        err_res.response().status(),
         StatusCode::NETWORK_AUTHENTICATION_REQUIRED
     );
 }


### PR DESCRIPTION
Fixes https://github.com/AaronErhardt/actix-governor/issues/51

This patch allows [ErrorHandlers](https://docs.rs/actix-web/latest/actix_web/middleware/struct.ErrorHandlers.html) to catch 5xx error responses generated by actix-governor