### PR TITLE
Update to governor 10 and allow accessing internal rate limiter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming::http-server"]
 actix-web = { version = "4", default-features = false }
 actix-http = "3"
 futures = "0.3"
-governor = "0.8.0"
+governor = "0.10.1"
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]
-actix-rt = "2.10"
+actix-rt = "2.11"
 actix-web = { version = "4", features = ["macros"] }
-serde = { version = "1.0.213",  features = ["derive"] }
+serde = { version = "1.0.228",  features = ["derive"] }
 
 [features]
 logger = ["log"]

--- a/examples/custom_key_bearer.rs
+++ b/examples/custom_key_bearer.rs
@@ -49,7 +49,7 @@ impl KeyExtractor for UserToken {
     }
 
     #[cfg(feature = "log")]
-    fn key_name(&self, key: &Self::Key) -> Option<String> {
+    fn key_name(&self, _key: &Self::Key) -> Option<String> {
         Some("String".to_owned())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,11 +139,22 @@
 //!
 //! # Common pitfalls
 //!
+//! ## Creating independant rate limiters
+//!
 //! Do not construct the same configuration multiple times, unless explicitly wanted!
 //! This will create an independent rate limiter for each configuration!
 //!
 //! Instead pass the same configuration reference into [`Governor::new()`],
 //! like it is described in the example.
+//!
+//! ## Memory leak (because of keys accumulation)
+//!
+//! If your application gets a lot of traffic and your rate limiter ends up with a lot of keys (for example, user tokens), you may observe some kind of memory leak: your application consumes more and more memory over time.
+//!
+//! In this case, you may want to regularly call [`governor::RateLimiter::retain_recent`] followed by [`governor::RateLimiter::shrink_to_fit`].
+//! These methods need to be called on the underlying [`governor::RateLimiter`] which can be accessed using [`GovernorConfig::limiter`].
+//!
+//! As you probably already have a Tokio context, you can do this from inside a task that is spawned after creating your rate limiter (`GovernorConfig` can be cloned while keeping the same underlying rate limiter).
 
 #![warn(
     rust_2018_idioms,
@@ -365,7 +376,7 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBuilder<PeerIpKeyEx
     /// Set the mode of the governor middleware.
     ///
     /// If permissive is set to true, the middleware will not block requests.
-    /// See also [`GovernorExtractor`](crate::GovernorExtractor).
+    /// See also [`GovernorExtractor`].
     pub const fn const_permissive(mut self, permissive: bool) -> Self {
         self.permissive = permissive;
         self
@@ -461,7 +472,7 @@ impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBu
     /// Set the mode of the governor middleware.
     ///
     /// If permissive is set to true, the middleware will not block requests.
-    /// See also [`GovernorExtractor`](crate::GovernorExtractor).
+    /// See also [`GovernorExtractor`].
     pub fn permissive(&mut self, permissive: bool) -> &mut Self {
         self.permissive = permissive;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,6 +584,13 @@ impl<M: RateLimitingMiddleware<QuantaInstant>> GovernorConfig<PeerIpKeyExtractor
     }
 }
 
+impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfig<K, M> {
+    /// Access internal [`governor::RateLimiter`]
+    pub fn limiter(&self) -> SharedRateLimiter<K::Key, M> {
+        self.limiter.clone()
+    }
+}
+
 /// Governor middleware factory.
 pub struct Governor<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> {
     key_extractor: K,


### PR DESCRIPTION
Hi!

My application had a memory leak and profiling pointed me to actix-governor/governor.

1. I updated to governor 10 (unrelated to my issue, but it does not hurt).
2. I added a `GovernorConfig::limiter` method that returns a reference to the underlying RateLimiter. Among other things, this can be used to call `retain_recent` et `shrink_to_fit` on it, which did resolved my memory leak issue, as I documented in the _Common pitfalls_ section.
3. The other minor changes are related to fixing rustc/Rustdoc warnings.