### PR TITLE
Improve GovernorConfig docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ async fn main() -> std::io::Result<()> {
         .finish()
         .unwrap();
 
+    // Configuration should be created before the server
     HttpServer::new(move || {
         App::new()
             // Enable Governor middleware

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,14 @@
 //!         .finish()
 //!         .unwrap();
 //!
+//!     // Configuration should be created before the server
 //!     HttpServer::new(move || {
 //!         App::new()
 //!             // Enable Governor middleware
 //!             .wrap(Governor::new(&governor_conf))
 //!             // Route hello world service
 //!             .route("/", web::get().to(index))
-//!    })
+//!     })
 //!     .bind("127.0.0.1:8080")?
 //!     .run()
 //!     .await
@@ -146,6 +147,8 @@
 //!
 //! Instead pass the same configuration reference into [`Governor::new()`],
 //! like it is described in the example.
+//!
+//! Cloning does not create an independent rate limiter.
 //!
 //! ## Memory leak (because of keys accumulation)
 //!
@@ -549,6 +552,8 @@ impl<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> GovernorConfigBu
 #[derive(Debug)]
 #[must_use]
 /// Configuration for the Governor middleware.
+///
+/// Contains the current state of the rate limiter.
 pub struct GovernorConfig<K: KeyExtractor, M: RateLimitingMiddleware<QuantaInstant>> {
     key_extractor: K,
     limiter: SharedRateLimiter<K::Key, M>,


### PR DESCRIPTION
Some documentation improvements.

- It seems that cloning of a configuration doesn't create a separate rate limiter. Is that correct?
- I think we could add a warning directly to the example, because it is easy to forget that application factory is called every time a worker is started.


